### PR TITLE
Add option to push multiarch Docker images

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -8,7 +8,7 @@ if [[ $ACTION == "push_image" ]];then
   echo "--- :floppy_disk: Push $ENVIRONMENT image for $APP"
 
   # Push the docker image
-  push_image --account_id $ACCOUNT_ID --app $APP --tag $DOCKER_TAG
+  push_image --account_id $ACCOUNT_ID --app $APP --tag $DOCKER_TAG --multiarch $MULTIARCH_IMAGE_PUSH
 
   # For dev, other images like database and test and master should be pushed.
   if [[ "$ENVIRONMENT" == "qa" ]]; then
@@ -18,13 +18,13 @@ if [[ $ACTION == "push_image" ]];then
     if [[ "$BK_BRANCH" == "$BUILDKITE_PIPELINE_DEFAULT_BRANCH" ]]; then
       echo "$BUILDKITE_PIPELINE_DEFAULT_BRANCH test image "
       BK_BRANCH="test-$BK_BRANCH"
-      push_image --account_id $ACCOUNT_ID --app $APP --tag test
+      push_image --account_id $ACCOUNT_ID --app $APP --tag test --multiarch $MULTIARCH_IMAGE_PUSH
     fi
-    
+
     if [[ "$HAS_DB_IMAGE" == "true" ]]; then
       echo "DB image"
       BK_BRANCH="database-$INITIAL_BK_BRANCH"
-      push_image --account_id $ACCOUNT_ID --app $APP --tag database
+      push_image --account_id $ACCOUNT_ID --app $APP --tag database --multiarch false
     fi
   fi
 elif [[ $ACTION == "push_param" ]];then

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -38,6 +38,7 @@ export TARGET_TAG="${BUILDKITE_PLUGIN_SBC_SHARED_TARGET_TAG:-}"
 set -u
 export DOCKER_TAG="${BUILDKITE_PLUGIN_SBC_SHARED_TAG:-application}"
 export HAS_DB_IMAGE="${BUILDKITE_PLUGIN_SBC_SHARED_DB_IMAGE:-false}"
+export MULTIARCH_IMAGE_PUSH="${BUILDKITE_PLUGIN_SBC_SHARED_MULTIARCH_IMAGE_PUSH:-false}"
 
 # copy scripts to be used by pipeline in order to be invoked within a docker container.
 ACTION="$BUILDKITE_PLUGIN_SBC_SHARED_ACTION"


### PR DESCRIPTION
You can now provide an additional option to the `push_image` action in order to push multiarch (`x86_64` and `arm64`) Docker images into AWS ECR. You can use it like this:
```
- sage/sbc-shared#multiarch-image-push:
    action: push_image
    environment: qa
    landscape: eu
    account_id: "123123123123"
    region: "eu-west-1"
    db_image: true
    multiarch_image_push: true
```

The only thing you have to make sure is that before running the `push_image` action, you have to build an additional `arm64` Docker image (with the tag suffix `arm64`).