### PR TITLE
Region agnostic ECR pushing

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -4,7 +4,7 @@ set -euo pipefail
 
 ACTION="$BUILDKITE_PLUGIN_SBC_SHARED_ACTION"
 
-if [[ $ACTION == "push_image" ]];then
+if [[ $ACTION == "push_image" ]]; then
   echo "--- :floppy_disk: Push $ENVIRONMENT image for $APP"
 
   # Push the docker image

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -27,9 +27,9 @@ if [[ -z $GEM_HOST ]]; then
   unset GEM_HOST
 fi
 
-# Only export the AWS_REGION if it was specified to be overriden.
+# Only export the REGION if it was specified to be overriden.
 if [[ -n $BUILDKITE_PLUGIN_SBC_SHARED_REGION ]]; then
-  export AWS_REGION="${BUILDKITE_PLUGIN_SBC_SHARED_REGION}"
+  export REGION="${BUILDKITE_PLUGIN_SBC_SHARED_REGION}"
 fi
 
 # If the target image needs to have a custom tag other than the GH tag/branch

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -122,7 +122,7 @@ push_image () {
   switches "$@"
   validate_switches account_id app tag multiarch
   varx BUILDKITE_BUILD_NUMBER
-  varx AWS_REGION
+  varx REGION
   varx BK_BRANCH
 
   # If the override ENV option was specified in the pipeline, use that tag value.
@@ -137,7 +137,7 @@ push_image () {
     X86_64_TAG_SUFFIX=-x86_64
   fi
 
-  TARGET_ECR=$account_id.dkr.ecr.$AWS_REGION.amazonaws.com/$REPO:$target_tag
+  TARGET_ECR=$account_id.dkr.ecr.$REGION.amazonaws.com/$REPO:$target_tag
 
   SOURCE_IMAGE_X86_64=$BK_ECR:$app-$tag-build-$BUILDKITE_BUILD_NUMBER
   TARGET_IMAGE_X86_64=$TARGET_ECR$X86_64_TAG_SUFFIX

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -32,8 +32,8 @@ setup() {
     export BUILDKIT_PROGRESS=plain
   fi
 
-  export BK_ECR=268539851198.dkr.ecr.eu-west-1.amazonaws.com/sageone/buildkite
-  export BK_CACHE=268539851198.dkr.ecr.eu-west-1.amazonaws.com/sageone/cache
+  export BK_ECR=268539851198.dkr.ecr.$AWS_REGION.amazonaws.com/sageone/buildkite
+  export BK_CACHE=268539851198.dkr.ecr.$AWS_REGION.amazonaws.com/sageone/cache
 
   # Needed for --cache-from and --cache-to
   docker buildx create --use --bootstrap


### PR DESCRIPTION
Allows the Buildkite agent queue to use a region-local ECR registry for temporary image storage instead of always assuming `eu-west-1`. This only affects images that are saved so they can be shared between build steps, not the final delivery destinations.