### PR TITLE
Rename REGION to S1_REGION and use for pushing SSM and ECR

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -31,11 +31,11 @@ if [[ $ACTION == "push_image" ]]; then
     fi
   fi
 elif [[ $ACTION == "push_param" ]]; then
- config_path=$ENVIRONMENT/$LANDSCAPE
+  config_path=$ENVIRONMENT/$LANDSCAPE
 
   # change directory from which all param logic expects to be run from.
   cd configuration
- ./push.sh $config_path
+  AWS_REGION=$S1_REGION ./push.sh $config_path
 elif [[ $ACTION == "publish_gem" ]]; then
   echo ""
 elif [[ $ACTION == "build" ]]; then

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -27,9 +27,9 @@ if [[ -z $GEM_HOST ]]; then
   unset GEM_HOST
 fi
 
-# Only export the REGION if it was specified to be overriden.
+# Only export the S1_REGION if it was specified to be overriden.
 if [[ -n $BUILDKITE_PLUGIN_SBC_SHARED_REGION ]]; then
-  export REGION="${BUILDKITE_PLUGIN_SBC_SHARED_REGION}"
+  export S1_REGION="${BUILDKITE_PLUGIN_SBC_SHARED_REGION}"
 fi
 
 # If the target image needs to have a custom tag other than the GH tag/branch

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -122,7 +122,7 @@ push_image () {
   switches "$@"
   validate_switches account_id app tag multiarch
   varx BUILDKITE_BUILD_NUMBER
-  varx REGION
+  varx S1_REGION
   varx BK_BRANCH
 
   # If the override ENV option was specified in the pipeline, use that tag value.
@@ -137,7 +137,7 @@ push_image () {
     X86_64_TAG_SUFFIX=-x86_64
   fi
 
-  TARGET_ECR=$account_id.dkr.ecr.$REGION.amazonaws.com/$REPO:$target_tag
+  TARGET_ECR=$account_id.dkr.ecr.$S1_REGION.amazonaws.com/$REPO:$target_tag
 
   SOURCE_IMAGE_X86_64=$BK_ECR:$app-$tag-build-$BUILDKITE_BUILD_NUMBER
   TARGET_IMAGE_X86_64=$TARGET_ECR$X86_64_TAG_SUFFIX


### PR DESCRIPTION
Allow the custom region specified in the plugin to be passed on to the push param script without explicitly exporting it.
In addition, the variable is renamed to not have any potential clash with a generic name later on.

Tested with 
https://buildkite.com/sage-group-plc/s1-accounting-za-integrations/builds/141