### PR TITLE
Dedicated buildx builder

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -88,10 +88,11 @@ buildx() {
   fi
 
   docker buildx build \
-    -f $file \
+    --file $file \
     --build-arg CI_BRANCH \
     --build-arg CI_STRING_TIME \
     --build-arg CI_COMMIT \
+    --build-arg CACHEBUST=$(date +%Y-%m-%d) \
     --cache-to mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=$BK_CACHE:$APP-$tag-$cache_id \
     --cache-from $BK_CACHE:$APP-$tag-$cache_id \
     --cache-from $BK_CACHE:$APP-$tag-$BUILDKITE_PIPELINE_DEFAULT_BRANCH \
@@ -102,10 +103,9 @@ buildx() {
     --ssh default \
     $OPTIONAL_TARGET \
     --load \
-    -t $REPO:$tag \
+    --tag $REPO:$tag \
     .
 }
-
 
 # Push an image into the BK ECR
 pushx () {
@@ -116,7 +116,7 @@ pushx () {
 
   echo "--- :floppy_disk: Push $tag"
   local BUILD_IMAGE_NAME=$BK_ECR:$app-$tag-build-$BUILDKITE_BUILD_NUMBER
-  docker tag  $REPO:$tag $BUILD_IMAGE_NAME
+  docker tag $REPO:$tag $BUILD_IMAGE_NAME
   docker push $BUILD_IMAGE_NAME
 }
 

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -37,7 +37,10 @@ setup() {
   export BK_CACHE=268539851198.dkr.ecr.$AWS_REGION.amazonaws.com/sageone/cache
 
   # Needed for --cache-from and --cache-to
-  docker buildx create --use --bootstrap
+  local builder_name=buildx-builder
+  if ! docker buildx inspect $builder_name > /dev/null 2>&1; then
+    docker buildx create --driver docker-container --name $builder_name --use --bootstrap
+  fi
 }
 
 # convert --<switch> to a variable


### PR DESCRIPTION
Creates and reuses a buildx builder instance instead of creating a new one for each build. This is necessary for `--mount=type=cache` to work since the cache is scoped to the instance.

Also makes `CACHEBUST` available as a build argument with a value that changes daily. This is meant as an improved mechanism over the old `epoch` file. That file no longer needs to be created ahead of running `docker build` and doesn't need to be `.gitignore`d. To use the new mechanism, `ARG CACHEBUST` should be added to the `Dockerfile` however, without that, the build argument will just do nothing.

Arguments to `docker` have been cleaned up so they consistently use the `--long-form`.