### PR TITLE
Override base coverage

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -55,7 +55,7 @@ elif [[ $ACTION == "build" ]]; then
   # execute the predetermined build script that a repository must have.
   . ".buildkite/build.sh"
 elif [[ $ACTION == "coverage_metrics" ]]; then
-  . "$(dirname $BASH_SOURCE)/../lib/code_coverage_checker.sh"
+   compare_coverage_metrics --coverage "${COVERAGE:-}"
 else
   echo "Unsupport action name of $ACTION"
   exit 1

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -32,6 +32,11 @@ if [[ -n $BUILDKITE_PLUGIN_SBC_SHARED_REGION ]]; then
   export S1_REGION="${BUILDKITE_PLUGIN_SBC_SHARED_REGION}"
 fi
 
+export COVERAGE="${BUILDKITE_PLUGIN_SBC_SHARED_COVERAGE:-${COVERAGE:-}}"
+if [[ -z $COVERAGE ]]; then
+  unset COVERAGE
+fi
+
 # If the target image needs to have a custom tag other than the GH tag/branch
 export TARGET_TAG="${BUILDKITE_PLUGIN_SBC_SHARED_TARGET_TAG:-}"
 

--- a/lib/code_coverage_checker.sh
+++ b/lib/code_coverage_checker.sh
@@ -170,13 +170,17 @@ fi
 echo "Baseline coverage: ${baseline_coverage}%"
 echo "Current coverage: ${current_coverage}%"
 
-if awk -v current="$current_coverage" -v baseline="$baseline_coverage" 'BEGIN { exit !(current + 0 < baseline + 0) }'; then
-  echo "FAIL: PR coverage (${current_coverage}%) is below ${BASE_BRANCH} baseline (${baseline_coverage}%)."
-  annotate_coverage_gate "error" "Coverage check regression: PR coverage (${current_coverage}%) is
-                                  below ${BASE_BRANCH} baseline (${baseline_coverage}%)."
-  exit 1
+# if COVERAGE is set, use it as the threshold instead of the baseline coverage
+if [[ -n "${COVERAGE:-}" ]]; then
+  echo "Using COVERAGE threshold: ${COVERAGE}%"
+  baseline_coverage="$COVERAGE"
 fi
 
+if awk -v current="$current_coverage" -v baseline="$baseline_coverage" 'BEGIN { exit !(current + 0 < baseline + 0) }'; then
+  echo "FAIL: PR coverage (${current_coverage}%) is below ${BASE_BRANCH} baseline (${baseline_coverage}%)."
+  message="Coverage check regression: PR coverage (${current_coverage}%) is below ${BASE_BRANCH} baseline (${baseline_coverage}%)."
+  annotate_coverage_gate "error" "$message"
+
 echo "OK: PR coverage is >= ${BASE_BRANCH} baseline."
-annotate_coverage_gate "success" "Coverage check regression passed: PR coverage (${current_coverage}%) is
-                                 greater than or equal to ${BASE_BRANCH} baseline (${baseline_coverage}%)."
+annotate_coverage_gate "success" "Coverage check regression passed: PR coverage (${current_coverage}%) meets or exceeds
+                                  ${BASE_BRANCH} baseline (${baseline_coverage}%)."

--- a/lib/code_coverage_checker.sh
+++ b/lib/code_coverage_checker.sh
@@ -180,6 +180,8 @@ if awk -v current="$current_coverage" -v baseline="$baseline_coverage" 'BEGIN { 
   echo "FAIL: PR coverage (${current_coverage}%) is below ${BASE_BRANCH} baseline (${baseline_coverage}%)."
   message="Coverage check regression: PR coverage (${current_coverage}%) is below ${BASE_BRANCH} baseline (${baseline_coverage}%)."
   annotate_coverage_gate "error" "$message"
+  exit 1
+fi
 
 echo "OK: PR coverage is >= ${BASE_BRANCH} baseline."
 annotate_coverage_gate "success" "Coverage check regression passed: PR coverage (${current_coverage}%) meets or exceeds

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -172,6 +172,11 @@ push_image () {
 
 compare_coverage_metrics() {
   switches "$@"
-  validate_switches coverage
-  . "$(dirname $BASH_SOURCE)/../lib/code_coverage_checker.sh"
+
+  # Optional override: if --coverage was provided, propagate to the env var expected by code_coverage_checker.sh.
+  if [[ -n "${coverage:-}" ]]; then
+    export COVERAGE="$coverage"
+  fi
+
+  . "$(dirname "$BASH_SOURCE")/code_coverage_checker.sh"
 }

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -172,6 +172,6 @@ push_image () {
 
 compare_coverage_metrics() {
   switches "$@"
-  validate_switches coverage github_repository github_sha github_token
+  validate_switches coverage
   . "$(dirname $BASH_SOURCE)/../lib/code_coverage_checker.sh"
 }

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -169,3 +169,9 @@ push_image () {
     docker manifest push $TARGET_ECR
   fi
 }
+
+compare_coverage_metrics() {
+  switches "$@"
+  validate_switches coverage github_repository github_sha github_token
+  . "$(dirname $BASH_SOURCE)/../lib/code_coverage_checker.sh"
+}

--- a/plugin.yml
+++ b/plugin.yml
@@ -25,6 +25,8 @@ configuration:
       type: boolean
     extra_suffix:
       type: string
+    coverage:
+      type: float
   required:
     - action
   additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -26,7 +26,7 @@ configuration:
     extra_suffix:
       type: string
     coverage:
-      type: float
+      type: number
   required:
     - action
   additionalProperties: false


### PR DESCRIPTION
There are cases where removing unused code or files is necessary, which can result in the current build's coverage percentage being lower than that of the base branch. To accommodate this edge case, the plugin provides a `coverage: [coverage percentage]` option that allows you to temporarily override the base branch coverage threshold.
