### PR TITLE
Add support for COVERAGE_TOLERANCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ The coverage gate script performs the following steps:
    - Extracts the line coverage percentage from the PR.
 
 4. **Compares Coverage Metrics**
-   - Compares current PR coverage against baseline coverage.
-   - Fails (exit 1) if PR coverage is **below** baseline
-   - Passes (exit 0) if PR coverage is **equal to or above** baseline.
+   - Compares current PR coverage against a minimum allowed threshold.
+   - Computes threshold as: `baseline coverage - COVERAGE_TOLERANCE` (floored at 0).
+   - Fails (exit 1) if PR coverage is **below** the minimum allowed threshold.
+   - Passes (exit 0) if PR coverage is **equal to or above** the minimum allowed threshold.
+   - If `COVERAGE` is set, that value is used as baseline before tolerance is applied.
 
 5. **Annotates Buildkite**
    - Posts a success annotation if coverage passes.
@@ -44,6 +46,8 @@ Environment variables to customize behavior:
 | `BUILDKITE_PIPELINE_SLUG` | (from env) | Pipeline name; reads from `BUILDKITE_PIPELINE_SLUG` if set |
 | `BASE_BRANCH` | `master` | Baseline branch for coverage comparison |
 | `BUILDKITE_BUILD_NUMBER` | (from env) | Current build number (auto-set in CI) |
+| `COVERAGE` | (unset) | Optional baseline override for coverage threshold |
+| `COVERAGE_TOLERANCE` | `0.00` | Allowed reduction in coverage percentage points |
 | `BASELINE_COVERAGE_ARTIFACT` | `coverage/.last_run.json` | Path to baseline coverage artifact in Buildkite |
 | `CURRENT_COVERAGE_ARTIFACT` | `coverage/.last_run.json` | Path to current PR coverage artifact in Buildkite |
 | `BASELINE_ARTIFACTS_JSON` | `base_artifacts.json` | Local filename for baseline artifact list |

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -37,6 +37,11 @@ if [[ -z $COVERAGE ]]; then
   unset COVERAGE
 fi
 
+export COVERAGE_TOLERANCE="${BUILDKITE_PLUGIN_SBC_SHARED_COVERAGE_TOLERANCE:-${COVERAGE_TOLERANCE:-}}"
+if [[ -z $COVERAGE_TOLERANCE ]]; then
+  unset COVERAGE_TOLERANCE
+fi
+
 # If the target image needs to have a custom tag other than the GH tag/branch
 export TARGET_TAG="${BUILDKITE_PLUGIN_SBC_SHARED_TARGET_TAG:-}"
 

--- a/lib/code_coverage_checker.sh
+++ b/lib/code_coverage_checker.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
 BUILDKITE_API_TOKEN="${BUILDKITE_API_TOKEN:-}"
 ORG="${ORG:-sage-group-plc}"
 BUILDKITE_PIPELINE_SLUG="${BUILDKITE_PIPELINE_SLUG:-}"
@@ -9,6 +10,9 @@ BUILDKITE_BUILD_NUMBER="${BUILDKITE_BUILD_NUMBER:-}"
 # Artifact paths to resolve from Buildkite artifacts API.
 BASELINE_COVERAGE_ARTIFACT="${BASELINE_COVERAGE_ARTIFACT:-coverage/.last_run.json}"
 CURRENT_COVERAGE_ARTIFACT="${CURRENT_COVERAGE_ARTIFACT:-coverage/.last_run.json}"
+
+# Allowed reduction in coverage, measured in percentage points.
+COVERAGE_TOLERANCE="${COVERAGE_TOLERANCE:-0.00}"
 
 # Local files written by this script.
 BASELINE_ARTIFACTS_JSON="${BASELINE_ARTIFACTS_JSON:-base_artifacts.json}"
@@ -21,47 +25,66 @@ annotate_coverage_gate() {
   local message="$2"
 
   if command -v buildkite-agent >/dev/null 2>&1; then
-    buildkite-agent annotate --style "$style" --context "coverage-gate" "$message" || true
+    buildkite-agent annotate \
+      --style "$style" \
+      --context "coverage-gate" \
+      "$message" || true
   fi
 }
 
-if [[ -z "${BUILDKITE_API_TOKEN:-}" ]]; then
+if [[ -z "$BUILDKITE_API_TOKEN" ]]; then
   echo "BUILDKITE_API_TOKEN is not set in this step environment." >&2
   exit 1
 fi
 
-if [[ -z "${BUILDKITE_PIPELINE_SLUG:-}" ]]; then
-  echo "BUILDKITE_PIPELINE_SLUG variables must be set to resolve Buildkite artifacts." >&2
+if [[ -z "$BUILDKITE_PIPELINE_SLUG" ]]; then
+  echo "BUILDKITE_PIPELINE_SLUG must be set to resolve Buildkite artifacts." >&2
   exit 1
 fi
 
-if [[ -z "${BUILDKITE_BUILD_NUMBER:-}" ]]; then
+if [[ -z "$BUILDKITE_BUILD_NUMBER" ]]; then
   echo "BUILDKITE_BUILD_NUMBER must be set to resolve current build artifacts." >&2
+  exit 1
+fi
+
+if ! awk \
+  -v tolerance="$COVERAGE_TOLERANCE" \
+  'BEGIN { exit !(tolerance ~ /^[0-9]+([.][0-9]+)?$/) }'
+then
+  echo "COVERAGE_TOLERANCE must be a non-negative numeric value (e.g. 0, 0.25, 1.5)." >&2
   exit 1
 fi
 
 buildkite_api_get() {
   local path="$1"
-  curl -sS -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
+
+  curl -sS \
+    -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
     "https://api.buildkite.com/v2/organizations/$ORG/pipelines/$BUILDKITE_PIPELINE_SLUG/$path"
 }
 
 latest_passed_build_id() {
   local branch="$1"
   local api_response
+  local build_id
 
-  api_response="$(buildkite_api_get "builds?branch=$branch&state=passed&page=1&per_page=100")"
+  api_response="$(
+    buildkite_api_get \
+      "builds?branch=$branch&state=passed&page=1&per_page=100"
+  )"
 
   if [[ -z "$api_response" ]]; then
     echo "API returned empty response for branch: $branch" >&2
     return 1
   fi
 
-  local build_id
-  build_id="$(echo "$api_response" \
-    | grep -oE '"number"[[:space:]]*:[[:space:]]*[0-9]+' \
-    | head -1 \
-    | grep -oE '[0-9]+' || true)"
+  build_id="$(
+    echo "$api_response" \
+      | grep -oE '"number"[[:space:]]*:[[:space:]]*[0-9]+' \
+      | head -1 \
+      | grep -oE '[0-9]+' \
+      || true
+  )"
 
   if [[ -z "$build_id" ]]; then
     echo "No passed builds found for branch: $branch" >&2
@@ -82,9 +105,11 @@ find_artifact_download_url() {
   while :; do
     page=$((page + 1))
 
-    buildkite_api_get "builds/$build_id/artifacts?page=$page&per_page=100" > "$artifacts_file"
+    buildkite_api_get \
+      "builds/$build_id/artifacts?page=$page&per_page=100" \
+      > "$artifacts_file"
 
-    # Stop iterating when API returns an empty page.
+    # Stop iterating when the API returns an empty page.
     if ! grep -q '"id"' "$artifacts_file"; then
       break
     fi
@@ -95,7 +120,8 @@ find_artifact_download_url() {
 {/g' \
         | grep -F "\"path\":\"$artifact_path\"" \
         | sed -n 's/.*"download_url":"\([^"]*\)".*/\1/p' \
-        | head -1 || true
+        | head -1 \
+        || true
     )"
 
     if [[ -n "$download_url" ]]; then
@@ -113,32 +139,47 @@ download_coverage_metrics() {
   local artifacts_file="$3"
   local output_file="$4"
   local label="$5"
-
   local download_url=""
-  download_url="$(find_artifact_download_url "$build_id" "$artifact_path" "$artifacts_file" || true)"
 
-  echo "$label download url: $download_url"
+  download_url="$(
+    find_artifact_download_url \
+      "$build_id" \
+      "$artifact_path" \
+      "$artifacts_file" \
+      || true
+  )"
+
+  echo "$label download URL: $download_url"
 
   if [[ -z "$download_url" ]]; then
+    local message
+
+    message="Coverage gate skipped: $label artifact '$artifact_path' is not available for build $build_id. Coverage comparison was not performed."
+
     echo "Artifact path '$artifact_path' was not found for build $build_id." >&2
-    annotate_coverage_gate "warning" "Coverage gate skipped: $label artifact '$artifact_path' is not available for build $build_id.
-    Coverage comparison was not performed."
+    annotate_coverage_gate "warning" "$message"
     exit 0
   fi
 
-  curl -sS -L -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
-    "$download_url" -o "$output_file"
+  curl -sS -L \
+    -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
+    "$download_url" \
+    -o "$output_file"
 }
 
 extract_line_coverage() {
   local file="$1"
-  sed -n 's/.*"line":[[:space:]]*\([0-9.][0-9.]*\).*/\1/p' "$file" | head -1
+
+  sed -n \
+    's/.*"line":[[:space:]]*\([0-9.][0-9.]*\).*/\1/p' \
+    "$file" \
+    | head -1
 }
 
 BASE_BUILD_ID="${BASE_BUILD_ID:-$(latest_passed_build_id "$BASE_BRANCH")}"
 
-if [[ -z "${BASE_BUILD_ID:-}" ]]; then
-  echo "Could not resolve BUILD_ID from Buildkite API response for branch '$BASE_BRANCH'." >&2
+if [[ -z "$BASE_BUILD_ID" ]]; then
+  echo "Could not resolve BASE_BUILD_ID from Buildkite API response for branch '$BASE_BRANCH'." >&2
   exit 1
 fi
 
@@ -158,7 +199,6 @@ download_coverage_metrics \
   "$CURRENT_COVERAGE_FILE" \
   "Current"
 
-
 baseline_coverage="$(extract_line_coverage "$BASELINE_COVERAGE_FILE")"
 current_coverage="$(extract_line_coverage "$CURRENT_COVERAGE_FILE")"
 
@@ -167,22 +207,51 @@ if [[ -z "$baseline_coverage" || -z "$current_coverage" ]]; then
   exit 1
 fi
 
-echo "Baseline coverage: ${baseline_coverage}%"
+echo "Downloaded baseline coverage: ${baseline_coverage}%"
 echo "Current coverage: ${current_coverage}%"
 
-# if COVERAGE is set, use it as the threshold instead of the baseline coverage
+coverage_baseline_label="${BASE_BRANCH} baseline"
+
+# If COVERAGE is set, use it as the threshold instead of the downloaded
+# baseline coverage.
 if [[ -n "${COVERAGE:-}" ]]; then
   echo "Using COVERAGE threshold: ${COVERAGE}%"
   baseline_coverage="$COVERAGE"
+  coverage_baseline_label="configured COVERAGE threshold"
 fi
 
-if awk -v current="$current_coverage" -v baseline="$baseline_coverage" 'BEGIN { exit !(current + 0 < baseline + 0) }'; then
-  echo "FAIL: PR coverage (${current_coverage}%) is below ${BASE_BRANCH} baseline (${baseline_coverage}%)."
-  message="Coverage check regression: PR coverage (${current_coverage}%) is below ${BASE_BRANCH} baseline (${baseline_coverage}%)."
+minimum_allowed_coverage="$(
+  awk \
+    -v baseline="$baseline_coverage" \
+    -v tolerance="$COVERAGE_TOLERANCE" \
+    'BEGIN {
+      minimum = baseline - tolerance
+
+      if (minimum < 0) {
+        minimum = 0
+      }
+
+      printf "%.4f", minimum
+    }'
+)"
+
+echo "Active baseline: ${baseline_coverage}% (${coverage_baseline_label})"
+echo "Coverage tolerance: ${COVERAGE_TOLERANCE}%"
+echo "Minimum allowed coverage: ${minimum_allowed_coverage}%"
+
+if awk \
+  -v current="$current_coverage" \
+  -v minimum="$minimum_allowed_coverage" \
+  'BEGIN { exit !(current + 0 < minimum + 0) }'
+then
+  message="Coverage regression failed: PR=${current_coverage}% baseline=${baseline_coverage}% tolerance=${COVERAGE_TOLERANCE}% minimum=${minimum_allowed_coverage}% source=${coverage_baseline_label}."
+
+  echo "FAIL: PR coverage (${current_coverage}%) is below the minimum allowed coverage (${minimum_allowed_coverage}%)."
   annotate_coverage_gate "error" "$message"
   exit 1
 fi
 
-echo "OK: PR coverage is >= ${BASE_BRANCH} baseline."
-annotate_coverage_gate "success" "Coverage check regression passed: PR coverage (${current_coverage}%) meets or exceeds
-                                  ${BASE_BRANCH} baseline (${baseline_coverage}%)."
+message="Coverage regression passed: PR=${current_coverage}% baseline=${baseline_coverage}% tolerance=${COVERAGE_TOLERANCE}% minimum=${minimum_allowed_coverage}% source=${coverage_baseline_label}."
+
+echo "OK: PR coverage (${current_coverage}%) is within tolerance of the ${coverage_baseline_label} (${baseline_coverage}%)."
+annotate_coverage_gate "success" "$message"

--- a/plugin.yml
+++ b/plugin.yml
@@ -27,6 +27,9 @@ configuration:
       type: string
     coverage:
       type: number
+    coverage_tolerance:
+      type: number
+      minimum: 0
   required:
     - action
   additionalProperties: false

--- a/tests/code_coverage_checker.bats
+++ b/tests/code_coverage_checker.bats
@@ -1,0 +1,150 @@
+#!/usr/bin/env bats
+
+load "$BATS_PLUGIN_PATH/load.bash"
+
+setup() {
+  export TEST_TMP_DIR
+  TEST_TMP_DIR="$(mktemp -d)"
+
+  export MOCK_BASE_BUILD="41"
+  export MOCK_CURRENT_BUILD="42"
+  export MOCK_BASE_DOWNLOAD_URL="https://example.com/base-coverage"
+  export MOCK_CURRENT_DOWNLOAD_URL="https://example.com/current-coverage"
+
+  export MOCK_BUILDS_RESPONSE="$TEST_TMP_DIR/builds_response.json"
+  export MOCK_BASE_ARTIFACTS_RESPONSE="$TEST_TMP_DIR/base_artifacts_response.json"
+  export MOCK_CURRENT_ARTIFACTS_RESPONSE="$TEST_TMP_DIR/current_artifacts_response.json"
+  export MOCK_BASE_COVERAGE_JSON="$TEST_TMP_DIR/base_coverage.json"
+  export MOCK_CURRENT_COVERAGE_JSON="$TEST_TMP_DIR/current_coverage.json"
+
+  cat > "$MOCK_BUILDS_RESPONSE" <<'JSON'
+[{"number":41}]
+JSON
+
+  cat > "$MOCK_BASE_ARTIFACTS_RESPONSE" <<'JSON'
+[{"id":"1","path":"coverage/.last_run.json","download_url":"https://example.com/base-coverage"}]
+JSON
+
+  cat > "$MOCK_CURRENT_ARTIFACTS_RESPONSE" <<'JSON'
+[{"id":"2","path":"coverage/.last_run.json","download_url":"https://example.com/current-coverage"}]
+JSON
+
+  mkdir -p "$TEST_TMP_DIR/fakebin"
+
+  cat > "$TEST_TMP_DIR/fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+args="$*"
+
+if [[ "$args" == *"/builds?branch="*"state=passed"* ]]; then
+  cat "$MOCK_BUILDS_RESPONSE"
+  exit 0
+fi
+
+if [[ "$args" == *"/builds/$MOCK_BASE_BUILD/artifacts?page=1&per_page=100"* ]]; then
+  cat "$MOCK_BASE_ARTIFACTS_RESPONSE"
+  exit 0
+fi
+
+if [[ "$args" == *"/builds/$MOCK_CURRENT_BUILD/artifacts?page=1&per_page=100"* ]]; then
+  cat "$MOCK_CURRENT_ARTIFACTS_RESPONSE"
+  exit 0
+fi
+
+if [[ "$args" == *"$MOCK_BASE_DOWNLOAD_URL"* || "$args" == *"$MOCK_CURRENT_DOWNLOAD_URL"* ]]; then
+  output_file=""
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "-o" ]]; then
+      output_file="$2"
+      break
+    fi
+    shift
+  done
+
+  if [[ -z "$output_file" ]]; then
+    echo "curl stub expected -o argument" >&2
+    exit 1
+  fi
+
+  if [[ "$args" == *"$MOCK_BASE_DOWNLOAD_URL"* ]]; then
+    cat "$MOCK_BASE_COVERAGE_JSON" > "$output_file"
+  else
+    cat "$MOCK_CURRENT_COVERAGE_JSON" > "$output_file"
+  fi
+
+  exit 0
+fi
+
+echo "Unexpected curl invocation: $args" >&2
+exit 1
+SH
+
+  chmod +x "$TEST_TMP_DIR/fakebin/curl"
+
+  export PATH="$TEST_TMP_DIR/fakebin:$PATH"
+  export BUILDKITE_API_TOKEN="token"
+  export BUILDKITE_PIPELINE_SLUG="my-pipeline"
+  export BASE_BRANCH="master"
+  export BUILDKITE_BUILD_NUMBER="$MOCK_CURRENT_BUILD"
+  export BASELINE_ARTIFACTS_JSON="$TEST_TMP_DIR/base_artifacts.json"
+  export CURRENT_ARTIFACTS_JSON="$TEST_TMP_DIR/current_artifacts.json"
+  export BASELINE_COVERAGE_FILE="$TEST_TMP_DIR/base_metrics.json"
+  export CURRENT_COVERAGE_FILE="$TEST_TMP_DIR/current_metrics.json"
+}
+
+teardown() {
+  rm -rf "$TEST_TMP_DIR"
+
+  unset MOCK_BASE_BUILD MOCK_CURRENT_BUILD MOCK_BASE_DOWNLOAD_URL MOCK_CURRENT_DOWNLOAD_URL
+  unset MOCK_BUILDS_RESPONSE MOCK_BASE_ARTIFACTS_RESPONSE MOCK_CURRENT_ARTIFACTS_RESPONSE
+  unset MOCK_BASE_COVERAGE_JSON MOCK_CURRENT_COVERAGE_JSON
+  unset BUILDKITE_API_TOKEN BUILDKITE_PIPELINE_SLUG BASE_BRANCH BUILDKITE_BUILD_NUMBER
+  unset BASELINE_ARTIFACTS_JSON CURRENT_ARTIFACTS_JSON BASELINE_COVERAGE_FILE CURRENT_COVERAGE_FILE
+  unset COVERAGE_TOLERANCE COVERAGE
+}
+
+@test "coverage checker passes when coverage drop is within COVERAGE_TOLERANCE" {
+  cat > "$MOCK_BASE_COVERAGE_JSON" <<'JSON'
+{"line":90.0}
+JSON
+
+  cat > "$MOCK_CURRENT_COVERAGE_JSON" <<'JSON'
+{"line":89.2}
+JSON
+
+  export COVERAGE_TOLERANCE="1.0"
+
+  run bash ./lib/code_coverage_checker.sh
+
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"Minimum allowed coverage: 89.0000%"* ]]
+  [[ "$output" == *"OK: PR coverage (89.2%) is within tolerance"* ]]
+}
+
+@test "coverage checker fails when coverage drop exceeds COVERAGE_TOLERANCE" {
+  cat > "$MOCK_BASE_COVERAGE_JSON" <<'JSON'
+{"line":90.0}
+JSON
+
+  cat > "$MOCK_CURRENT_COVERAGE_JSON" <<'JSON'
+{"line":88.8}
+JSON
+
+  export COVERAGE_TOLERANCE="1.0"
+
+  run bash ./lib/code_coverage_checker.sh
+
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"Minimum allowed coverage: 89.0000%"* ]]
+  [[ "$output" == *"FAIL: PR coverage (88.8%) is below the minimum allowed coverage (89.0000%)."* ]]
+}
+
+@test "coverage checker rejects invalid COVERAGE_TOLERANCE" {
+  export COVERAGE_TOLERANCE="abc"
+
+  run bash ./lib/code_coverage_checker.sh
+
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"COVERAGE_TOLERANCE must be a non-negative numeric value"* ]]
+}

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -30,3 +30,13 @@ teardown() {
 
   [[ -f .buildkite/release.sh ]]
 }
+
+@test "pre-command hook exports COVERAGE_TOLERANCE from plugin config" {
+  export BUILDKITE_PLUGIN_SBC_SHARED_ACTION="publish_gem"
+  export BUILDKITE_PLUGIN_SBC_SHARED_COVERAGE_TOLERANCE="1.25"
+
+  run bash -c 'source ./hooks/pre-command; echo "${COVERAGE_TOLERANCE:-}"'
+
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"1.25"* ]]
+}


### PR DESCRIPTION
This PR adds an optional coverage_tolerance var to allow consumer apps to define a threshold for acceptable drops in coverage. It would be recommended to keep this to a very low number, i.e. 0.01%, which will help minor drops on large PRs. 

Example use in consumer app:
```
        plugins:
          - ecr#v2.9.0:
              login: true
              account-ids: '522104923602'
              region: 'eu-west-1'
              assume_role:
                role_arn: 'arn:aws:iam::522104923602:role/CI.Integration'
          - ssh://git@github.com/Sage/sbc-shared-buildkite-plugin.git#2.10.1:
              action: coverage_metrics
              coverage_tolerance: 0.01
        depends_on: 'code-coverage'
```

What I changed
- General tidy up of lib/code_coverage_checker.sh
- Added runtime validation for coverage_tolerance in lib/code_coverage_checker.sh from line 215
- Added guard in case the consumer app tries to use a negative number
- Updated behaviour docs and config table
- Added pre-command propagation test