### PR TITLE
Update buildx and push_image to build with attestations

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -180,7 +180,7 @@ push_image () {
 
   echo "Pushing $SOURCE_IMAGE_X86_64 to $TARGET_IMAGE_X86_64"
 
-  docker pull $SOURCE_IMAGE_X86_64
+  docker pull $SOURCE_IMAGE_X86_64 --platform linux/amd64
   docker tag $SOURCE_IMAGE_X86_64 $TARGET_IMAGE_X86_64
   docker push $TARGET_IMAGE_X86_64
 
@@ -190,7 +190,7 @@ push_image () {
 
     echo "Pushing $SOURCE_IMAGE_ARM64 to $TARGET_IMAGE_ARM64"
 
-    docker pull $SOURCE_IMAGE_ARM64
+    docker pull $SOURCE_IMAGE_ARM64 --platform linux/arm64
     docker tag $SOURCE_IMAGE_ARM64 $TARGET_IMAGE_ARM64
     docker push $TARGET_IMAGE_ARM64
 

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -167,36 +167,20 @@ push_image () {
 
   echo "Pushing image for $app using tag: $target_tag"
 
-  local X86_64_TAG_SUFFIX=""
-
-  if [[ "$multiarch" == "true" ]]; then
-    X86_64_TAG_SUFFIX=-x86_64
-  fi
-
   TARGET_ECR=$account_id.dkr.ecr.$S1_REGION.amazonaws.com/$REPO:$target_tag
 
   SOURCE_IMAGE_X86_64=$BK_ECR:$app-$tag-build-$BUILDKITE_BUILD_NUMBER
-  TARGET_IMAGE_X86_64=$TARGET_ECR$X86_64_TAG_SUFFIX
 
-  echo "Pushing $SOURCE_IMAGE_X86_64 to $TARGET_IMAGE_X86_64"
+  echo "Creating and pushing manifest: $TARGET_ECR with $SOURCE_IMAGE_X86_64"
 
-  docker pull $SOURCE_IMAGE_X86_64 --platform linux/amd64
-  docker tag $SOURCE_IMAGE_X86_64 $TARGET_IMAGE_X86_64
-  docker push $TARGET_IMAGE_X86_64
+  docker buildx imagetools create -t $TARGET_ECR $SOURCE_IMAGE_X86_64
 
   if [[ "$multiarch" == "true" ]]; then
     SOURCE_IMAGE_ARM64=$BK_ECR:$app-$tag-arm64-build-$BUILDKITE_BUILD_NUMBER
-    TARGET_IMAGE_ARM64=$TARGET_ECR-arm64
 
-    echo "Pushing $SOURCE_IMAGE_ARM64 to $TARGET_IMAGE_ARM64"
+    echo "Appending manifest: $TARGET_ECR with $SOURCE_IMAGE_ARM64"
 
-    docker pull $SOURCE_IMAGE_ARM64 --platform linux/arm64
-    docker tag $SOURCE_IMAGE_ARM64 $TARGET_IMAGE_ARM64
-    docker push $TARGET_IMAGE_ARM64
-
-    echo "Creating and pushing manifest: $TARGET_ECR with $TARGET_IMAGE_X86_64 and $TARGET_IMAGE_ARM64"
-
-    docker buildx imagetools create -t $TARGET_ECR $TARGET_IMAGE_X86_64 $TARGET_IMAGE_ARM64
+    docker buildx imagetools create --append -t $TARGET_ECR $SOURCE_IMAGE_ARM64
   fi
 }
 

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -81,11 +81,13 @@ validate_switches() {
 #             (provenance + SBOM). When unset we --load into the local daemon
 #             (used for the test image), which cannot carry attestations.
 buildx() {
-  target=
-  push=
+  local target=
+  local push=
+
   switches "$@"
   validate_switches tag file cache_id
   varx REPO BUILDKITE_PIPELINE_DEFAULT_BRANCH BUILDKITE_BUILD_NUMBER
+
   echo "+++ :building_construction: Build $tag"
 
   local OPTIONAL_TARGET=
@@ -173,14 +175,14 @@ push_image () {
 
   echo "Creating and pushing manifest: $TARGET_ECR with $SOURCE_IMAGE_X86_64"
 
-  docker buildx imagetools create -t $TARGET_ECR $SOURCE_IMAGE_X86_64
+  docker buildx imagetools create --tag $TARGET_ECR $SOURCE_IMAGE_X86_64
 
   if [[ "$multiarch" == "true" ]]; then
     SOURCE_IMAGE_ARM64=$BK_ECR:$app-$tag-arm64-build-$BUILDKITE_BUILD_NUMBER
 
     echo "Appending manifest: $TARGET_ECR with $SOURCE_IMAGE_ARM64"
 
-    docker buildx imagetools create --append -t $TARGET_ECR $SOURCE_IMAGE_ARM64
+    docker buildx imagetools create --append --tag $TARGET_ECR $SOURCE_IMAGE_ARM64
   fi
 }
 

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -111,6 +111,8 @@ buildx() {
 
   local BUILD_IMAGE_NAME=$BK_ECR:$APP-$tag-build-$BUILDKITE_BUILD_NUMBER
 
+  echo "--- :docker: Building $tag as $BUILD_IMAGE_NAME with build args: $OPTIONAL_TARGET ${OUTPUT_ARGS[@]}"
+
   docker buildx build \
     --file $file \
     --pull \
@@ -138,9 +140,10 @@ pushx () {
   validate_switches app tag
   varx REPO BUILDKITE_BUILD_NUMBER
 
-  echo "--- :floppy_disk: Push $tag"
   local BUILD_IMAGE_NAME=$BK_ECR:$app-$tag-build-$BUILDKITE_BUILD_NUMBER
-  # docker tag $REPO:$tag $BUILD_IMAGE_NAME
+
+  echo "--- :floppy_disk: Push $tag as $BUILD_IMAGE_NAME"
+
   docker push $BUILD_IMAGE_NAME
 }
 
@@ -174,6 +177,9 @@ push_image () {
 
   SOURCE_IMAGE_X86_64=$BK_ECR:$app-$tag-build-$BUILDKITE_BUILD_NUMBER
   TARGET_IMAGE_X86_64=$TARGET_ECR$X86_64_TAG_SUFFIX
+
+  echo "Pushing $SOURCE_IMAGE_X86_64 to $TARGET_IMAGE_X86_64"
+
   docker pull $SOURCE_IMAGE_X86_64
   docker tag $SOURCE_IMAGE_X86_64 $TARGET_IMAGE_X86_64
   docker push $TARGET_IMAGE_X86_64
@@ -181,11 +187,15 @@ push_image () {
   if [[ "$multiarch" == "true" ]]; then
     SOURCE_IMAGE_ARM64=$BK_ECR:$app-$tag-arm64-build-$BUILDKITE_BUILD_NUMBER
     TARGET_IMAGE_ARM64=$TARGET_ECR-arm64
+
+    echo "Pushing $SOURCE_IMAGE_ARM64 to $TARGET_IMAGE_ARM64"
+
     docker pull $SOURCE_IMAGE_ARM64
     docker tag $SOURCE_IMAGE_ARM64 $TARGET_IMAGE_ARM64
     docker push $TARGET_IMAGE_ARM64
 
-    # Create & push manifest file for multiarch image
+    echo "Creating and pushing manifest: $TARGET_ECR with $TARGET_IMAGE_X86_64 and $TARGET_IMAGE_ARM64"
+
     docker manifest create $TARGET_ECR $TARGET_IMAGE_X86_64 $TARGET_IMAGE_ARM64
     docker manifest push $TARGET_ECR
   fi

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -196,8 +196,7 @@ push_image () {
 
     echo "Creating and pushing manifest: $TARGET_ECR with $TARGET_IMAGE_X86_64 and $TARGET_IMAGE_ARM64"
 
-    docker manifest create $TARGET_ECR $TARGET_IMAGE_X86_64 $TARGET_IMAGE_ARM64
-    docker manifest push $TARGET_ECR
+    docker buildx imagetools create -t $TARGET_ECR $TARGET_IMAGE_X86_64 $TARGET_IMAGE_ARM64
   fi
 }
 

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -73,16 +73,19 @@ validate_switches() {
   set -u
 }
 
-# target => (Optional) set the target build stage to build
-# tag => variant of the docker image e.g. app or database
-# file => source Dockerfile
+# target   => (Optional) set the target build stage to build
+# tag      => variant of the docker image e.g. app or database
+# file     => source Dockerfile
 # cache_id => typically the git branch name
+# push     => (Optional) "true" to push to the registry WITH attestations
+#             (provenance + SBOM). When unset we --load into the local daemon
+#             (used for the test image), which cannot carry attestations.
 buildx() {
   target=
+  push=
   switches "$@"
   validate_switches tag file cache_id
-  varx REPO BUILDKITE_PIPELINE_DEFAULT_BRANCH
-
+  varx REPO BUILDKITE_PIPELINE_DEFAULT_BRANCH BUILDKITE_BUILD_NUMBER
   echo "+++ :building_construction: Build $tag"
 
   local OPTIONAL_TARGET=
@@ -90,8 +93,27 @@ buildx() {
     OPTIONAL_TARGET="--target $target"
   fi
 
+  # Output + attestation strategy.
+  #
+  # --load routes through the classic docker image store, which cannot hold
+  # attestations (BuildKit silently drops them). So attestations only make
+  # sense on the --push path. For images we ship (and scan with Docker Scout)
+  # we push WITH:
+  #   --provenance=mode=max  records the full build graph + layer->step mapping
+  #                          so Scout can identify the DHI base image and split
+  #                          base-image CVEs from our app-layer CVEs.
+  #   --sbom=true            emits an SBOM attestation: exact package inventory
+  #                          and lets DHI's VEX / "not-affected" data apply.
+  local OUTPUT_ARGS=(--load)
+  if [[ $push == "true" ]]; then
+    OUTPUT_ARGS=(--push --provenance=mode=max --sbom=true)
+  fi
+
+  local BUILD_IMAGE_NAME=$BK_ECR:$APP-$tag-build-$BUILDKITE_BUILD_NUMBER
+
   docker buildx build \
     --file $file \
+    --pull \
     --build-arg CI_BRANCH \
     --build-arg CI_STRING_TIME \
     --build-arg CI_COMMIT \
@@ -105,8 +127,8 @@ buildx() {
     --secret id=jfrog_nuget,env=NUGET_JFROG_PASSWORD \
     --ssh default \
     $OPTIONAL_TARGET \
-    --load \
-    --tag $REPO:$tag \
+    "${OUTPUT_ARGS[@]}" \
+    --tag $BUILD_IMAGE_NAME \
     .
 }
 
@@ -118,7 +140,7 @@ pushx () {
 
   echo "--- :floppy_disk: Push $tag"
   local BUILD_IMAGE_NAME=$BK_ECR:$app-$tag-build-$BUILDKITE_BUILD_NUMBER
-  docker tag $REPO:$tag $BUILD_IMAGE_NAME
+  # docker tag $REPO:$tag $BUILD_IMAGE_NAME
   docker push $BUILD_IMAGE_NAME
 }
 

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -49,18 +49,14 @@ set_up_push_image_env_vars() {
 @test "push_image action pulls, tags, and pushes the docker image" {
   set_up_push_image_env_vars
 
-  stub docker "pull 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123 --platform linux/amd64 : echo pulling"
-  stub docker "tag 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:mybranch : echo tagging"
-  stub docker "push 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:mybranch : echo pushing"
+  stub docker "buildx imagetools create -t 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:mybranch 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123 : echo pushing manifest"
 
   run -0 ./hooks/post-command
 
   [[ "${lines[0]}" == *"--- :floppy_disk: Push test image for myapp"* ]]
   [[ "${lines[1]}" == *"Pushing image for myapp using tag: mybranch"* ]]
-  [[ "${lines[2]}" == *"Pushing"* ]]
-  [[ "${lines[3]}" == *"pulling"* ]]
-  [[ "${lines[4]}" == *"tagging"* ]]
-  [[ "${lines[5]}" == *"pushing"* ]]
+  [[ "${lines[2]}" == *"Creating and pushing manifest: 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:mybranch with 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123"* ]]
+  [[ "${lines[3]}" == *"pushing manifest"* ]]
 
   unstub docker
 }
@@ -69,14 +65,14 @@ set_up_push_image_env_vars() {
   set_up_push_image_env_vars
   export ENVIRONMENT="qa"
 
-  stub docker "pull 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123 --platform linux/amd64 : echo pulling app image"
-  stub docker "tag 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:mybranch : echo tagging"
-  stub docker "push 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:mybranch : echo pushing"
-  stub docker "pull 123.buildkite.ecr.repo/myrepo:myapp-database-build-123 --platform linux/amd64 : echo pulling db image"
-  stub docker "tag 123.buildkite.ecr.repo/myrepo:myapp-database-build-123 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:database-mybranch : echo tagging db image"
-  stub docker "push 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:database-mybranch : echo pushing db image"
+  stub docker "buildx imagetools create -t 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:mybranch 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123 : echo pushing app manifest"
+  stub docker "buildx imagetools create -t 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:database-mybranch 123.buildkite.ecr.repo/myrepo:myapp-database-build-123 : echo pushing db manifest"
 
   run -0 ./hooks/post-command
+
+  [[ "$output" == *"pushing app manifest"* ]]
+  [[ "$output" == *"DB image"* ]]
+  [[ "$output" == *"pushing db manifest"* ]]
 
   unstub docker
 }

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -49,7 +49,7 @@ set_up_push_image_env_vars() {
 @test "push_image action pulls, tags, and pushes the docker image" {
   set_up_push_image_env_vars
 
-  stub docker "pull 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123 : echo pulling"
+  stub docker "pull 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123 --platform linux/amd64 : echo pulling"
   stub docker "tag 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:mybranch : echo tagging"
   stub docker "push 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:mybranch : echo pushing"
 
@@ -57,9 +57,10 @@ set_up_push_image_env_vars() {
 
   [[ "${lines[0]}" == *"--- :floppy_disk: Push test image for myapp"* ]]
   [[ "${lines[1]}" == *"Pushing image for myapp using tag: mybranch"* ]]
-  [[ "${lines[2]}" == *"pulling"* ]]
-  [[ "${lines[3]}" == *"tagging"* ]]
-  [[ "${lines[4]}" == *"pushing"* ]]
+  [[ "${lines[2]}" == *"Pushing"* ]]
+  [[ "${lines[3]}" == *"pulling"* ]]
+  [[ "${lines[4]}" == *"tagging"* ]]
+  [[ "${lines[5]}" == *"pushing"* ]]
 
   unstub docker
 }
@@ -68,10 +69,10 @@ set_up_push_image_env_vars() {
   set_up_push_image_env_vars
   export ENVIRONMENT="qa"
 
-  stub docker "pull 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123 : echo pulling app image"
+  stub docker "pull 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123 --platform linux/amd64 : echo pulling app image"
   stub docker "tag 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:mybranch : echo tagging"
   stub docker "push 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:mybranch : echo pushing"
-  stub docker "pull 123.buildkite.ecr.repo/myrepo:myapp-database-build-123 : echo pulling db image"
+  stub docker "pull 123.buildkite.ecr.repo/myrepo:myapp-database-build-123 --platform linux/amd64 : echo pulling db image"
   stub docker "tag 123.buildkite.ecr.repo/myrepo:myapp-database-build-123 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:database-mybranch : echo tagging db image"
   stub docker "push 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:database-mybranch : echo pushing db image"
 


### PR DESCRIPTION
As part of onboarding repos to use Docker Hardened Images, update the `buildx` function to push image manifests containing attesations and SBOM, as well as maintain these between different ECR repositories.

**Notes**

One concern I had was how our lifecycle policies and cleanup scripts would handle untagged images in ECR which are part of a manifest. Documented findings in this PDF.

[Docker imagetools and ecr cleanup.pdf](https://github.com/user-attachments/files/30264178/Docker.imagetools.and.ecr.cleanup.pdf)

