### PR TITLE
Make push_image compatible with immutable repos

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -173,16 +173,16 @@ push_image () {
 
   SOURCE_IMAGE_X86_64=$BK_ECR:$app-$tag-build-$BUILDKITE_BUILD_NUMBER
 
-  echo "Creating and pushing manifest: $TARGET_ECR with $SOURCE_IMAGE_X86_64"
-
-  docker buildx imagetools create --tag $TARGET_ECR $SOURCE_IMAGE_X86_64
-
   if [[ "$multiarch" == "true" ]]; then
     SOURCE_IMAGE_ARM64=$BK_ECR:$app-$tag-arm64-build-$BUILDKITE_BUILD_NUMBER
 
-    echo "Appending manifest: $TARGET_ECR with $SOURCE_IMAGE_ARM64"
+    echo "Creating multi-arch manifest: $TARGET_ECR with $SOURCE_IMAGE_X86_64 and $SOURCE_IMAGE_ARM64"
 
-    docker buildx imagetools create --append --tag $TARGET_ECR $SOURCE_IMAGE_ARM64
+    docker buildx imagetools create --tag $TARGET_ECR $SOURCE_IMAGE_X86_64 $SOURCE_IMAGE_ARM64
+  else
+    echo "Creating manifest: $TARGET_ECR with $SOURCE_IMAGE_X86_64"
+
+    docker buildx imagetools create --tag $TARGET_ECR $SOURCE_IMAGE_X86_64
   fi
 }
 

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -49,14 +49,30 @@ set_up_push_image_env_vars() {
 @test "push_image action pulls, tags, and pushes the docker image" {
   set_up_push_image_env_vars
 
-  stub docker "buildx imagetools create -t 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:mybranch 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123 : echo pushing manifest"
+  stub docker "buildx imagetools create --tag 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:mybranch 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123 : echo pushing manifest"
 
   run -0 ./hooks/post-command
 
   [[ "${lines[0]}" == *"--- :floppy_disk: Push test image for myapp"* ]]
   [[ "${lines[1]}" == *"Pushing image for myapp using tag: mybranch"* ]]
-  [[ "${lines[2]}" == *"Creating and pushing manifest: 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:mybranch with 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123"* ]]
+  [[ "${lines[2]}" == *"Creating manifest: 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:mybranch with 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123"* ]]
   [[ "${lines[3]}" == *"pushing manifest"* ]]
+
+  unstub docker
+}
+
+@test "push_image with multiarch=true creates single manifest with both images" {
+  set_up_push_image_env_vars
+  export MULTIARCH_IMAGE_PUSH="true"
+
+  stub docker "buildx imagetools create --tag 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:mybranch 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123 123.buildkite.ecr.repo/myrepo:myapp-mytag-arm64-build-123 : echo pushing multi-arch manifest"
+
+  run -0 ./hooks/post-command
+
+  [[ "${lines[0]}" == *"--- :floppy_disk: Push test image for myapp"* ]]
+  [[ "${lines[1]}" == *"Pushing image for myapp using tag: mybranch"* ]]
+  [[ "${lines[2]}" == *"Creating multi-arch manifest: 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:mybranch with 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123 and 123.buildkite.ecr.repo/myrepo:myapp-mytag-arm64-build-123"* ]]
+  [[ "${lines[3]}" == *"pushing multi-arch manifest"* ]]
 
   unstub docker
 }
@@ -65,8 +81,8 @@ set_up_push_image_env_vars() {
   set_up_push_image_env_vars
   export ENVIRONMENT="qa"
 
-  stub docker "buildx imagetools create -t 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:mybranch 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123 : echo pushing app manifest"
-  stub docker "buildx imagetools create -t 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:database-mybranch 123.buildkite.ecr.repo/myrepo:myapp-database-build-123 : echo pushing db manifest"
+  stub docker "buildx imagetools create --tag 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:mybranch 123.buildkite.ecr.repo/myrepo:myapp-mytag-build-123 : echo pushing app manifest"
+  stub docker "buildx imagetools create --tag 123.dkr.ecr.made-up-region.amazonaws.com/myrepo:database-mybranch 123.buildkite.ecr.repo/myrepo:myapp-database-build-123 : echo pushing db manifest"
 
   run -0 ./hooks/post-command
 


### PR DESCRIPTION
Using `docker buildx imagetools create --append` is not compatible with immutable repositories. Instead, create the manifest list and push it to the registry in one command.